### PR TITLE
Implement pause functionality with pause screen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+export GDK ?= /opt/toolchains/mars/m68k-elf
+include $(GDK)/makefile.gen

--- a/inc/globals.h
+++ b/inc/globals.h
@@ -164,6 +164,11 @@ extern u16 coffset;
 extern u16 STRIP_TILE_8_IDX;
 extern u16 EMPTY_BAR_TILE_IDX;
 
+// Pause state
+extern u16 game_paused;
+// Detect start press instead of start down
+extern u16 start_was_pressed;
+
 // Title screen
 extern s16 control_style;
 extern s16 control_style_old;

--- a/inc/pause.h
+++ b/inc/pause.h
@@ -1,0 +1,8 @@
+#ifndef PAUSE_H
+#define PAUSE_H
+
+#include "globals.h"
+
+void pause_screen(void);
+
+#endif // PAUSE_H

--- a/res/resources.h
+++ b/res/resources.h
@@ -3,14 +3,34 @@
 #ifndef _RES_RESOURCES_H_
 #define _RES_RESOURCES_H_
 
-extern const u8 sfx_laser[2304];
-extern const u8 track1[124160];
-extern const Palette bg_far_palette;
-extern const TileSet bg_far_tiles;
-extern const Palette bg_near_palette;
-extern const TileSet bg_near_tiles;
-extern const Palette player_palette;
+extern const u8 sfx_laser[2048];
+extern const u8 sfx_elaser[2816];
+extern const u8 sfx_explode[6656];
+extern const u8 sfx_ding[6656];
+extern const u8 sfx_turbo[6656];
+extern const u8 sfx_mexplode[6656];
+extern const u8 sfx_sbullet[2816];
+extern const u8 track1[2816];
+extern const u8 title_music[3328];
+extern const TileSet player_score_tiles;
+extern const Image starbg;
+extern const Image title;
 extern const SpriteDefinition player_sprite_res;
+extern const SpriteDefinition mine_explode_res;
 extern const SpriteDefinition bullet_sprite_res;
+extern const SpriteDefinition sbullet_sprite_res;
+extern const SpriteDefinition ebullet_sprite_res;
+extern const SpriteDefinition fighter_sprite_res;
+extern const SpriteDefinition fighter_explode_res;
+extern const SpriteDefinition space_mine_res;
+extern const Palette player_palette;
+extern const Palette player_pal2;
+extern const Palette player_pal3;
+extern const Palette player_pal4;
+extern const Palette star_bg_pal;
+extern const Palette title_pal_1;
+extern const Palette title_pal_2;
+extern const Palette title_pal_3;
+extern const Palette title_pal_4;
 
 #endif // _RES_RESOURCES_H_

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 
 #include "fighters.h"
 #include "background.h"
+#include "pause.h"      // Pause screen
 
 // // Palette for debug font (can be here or in globals/game_data if shared)
 // const u16 debug_font_palette[16] = {
@@ -28,6 +29,9 @@
 
 // u16 ind = TILE_USER_INDEX;
 // Map* star_map;
+
+u16 game_paused = 0;
+u16 start_was_pressed = 0;
 
 int main()
 {
@@ -73,7 +77,6 @@ int main()
     init_game_vars(); // Set up player/enemy scores
 
     title_screen();   // Show title screen.
-
     PAL_setPalette(PAL3, title_pal_1.data, DMA_QUEUE); // reset PAL3 after title
 
     initBackground(); // Initializes tiles, maps, and initial scroll
@@ -102,6 +105,9 @@ int main()
     while (1)
     {
         handleInput();
+        if (game_paused) {
+            pause_screen();
+        }
         playerBoost(); // Apply boost if needed.  Must be called before updatePhysics.
         updatePhysics();
 

--- a/src/pause.c
+++ b/src/pause.c
@@ -1,0 +1,57 @@
+#include "pause.h"
+#include <genesis.h>
+#include "globals.h" // For screen dimensions, game_paused, etc.
+
+void pause_screen(void) {
+    // Draw PAUSE centered
+    VDP_clearText(0, (screen_height_pixels_d2 / 8) - 3, 40); // Clear center line
+    VDP_drawText("PAUSE", (screen_width_pixels_d2 / 8) - 3, screen_height_pixels_d2 / 8);
+    SPR_setVisibility(player_sprite, HIDDEN);
+
+    for (s16 i = 0; i < NEBULLET; i++) {
+        if(ebullets[i].sprite_ptr != NULL) SPR_setVisibility(ebullets[i].sprite_ptr, HIDDEN);
+	}
+
+	for (s16 i = 0; i < NBULLET; i++) {
+        if(bullets[i].sprite_ptr != NULL) SPR_setVisibility(bullets[i].sprite_ptr, HIDDEN);
+    }
+
+    for (s16 i = 0; i < active_fighter_count; i++) {
+        if(fighters[i].sprite_ptr != NULL) SPR_setVisibility(fighters[i].sprite_ptr, HIDDEN);
+        if(fexplode[i].sprite_ptr != NULL) SPR_setVisibility(fexplode[i].sprite_ptr, HIDDEN);
+    }
+
+    for (s16 i = 0; i < NSBULLET; i++) {
+        if(sbullets[i].sprite_ptr != NULL) SPR_setVisibility(sbullets[i].sprite_ptr, HIDDEN);
+    }
+
+    if(mine_sprite_ptr) SPR_setVisibility(mine_sprite_ptr, HIDDEN);
+    if (mexplode_sprite_ptr) SPR_setVisibility(mexplode_sprite_ptr, HIDDEN);
+
+    while (1) {
+        u16 value = JOY_readJoypad(JOY_1);
+        if (value & BUTTON_START) {
+            break;
+        }
+        SPR_update();
+        SYS_doVBlankProcess();
+    }
+    VDP_clearText(0, screen_height_pixels_d2 / 8, 40); // Clear PAUSE when resuming
+    SPR_setVisibility(player_sprite, VISIBLE); // Restore player sprite visibility
+
+    for (s16 i = 0; i < NEBULLET; i++) {
+        if(ebullets[i].sprite_ptr != NULL) SPR_setVisibility(ebullets[i].sprite_ptr, VISIBLE);
+    }
+    for (s16 i = 0; i < NBULLET; i++) {
+        if(bullets[i].sprite_ptr != NULL) SPR_setVisibility(bullets[i].sprite_ptr, VISIBLE);
+    }
+    for (s16 i = 0; i < active_fighter_count; i++) {
+        if(fighters[i].sprite_ptr != NULL) SPR_setVisibility(fighters[i].sprite_ptr, VISIBLE);
+        if(fexplode[i].sprite_ptr != NULL) SPR_setVisibility(fexplode[i].sprite_ptr, VISIBLE);
+    }
+    for (s16 i = 0; i < NSBULLET; i++) {
+        if(sbullets[i].sprite_ptr != NULL) SPR_setVisibility(sbullets[i].sprite_ptr, VISIBLE);
+    }   
+    if(mine_sprite_ptr) SPR_setVisibility(mine_sprite_ptr, VISIBLE);
+    if (mexplode_sprite_ptr) SPR_setVisibility(mexplode_sprite_ptr, VISIBLE);
+}

--- a/src/player.c
+++ b/src/player.c
@@ -13,6 +13,15 @@ void handleInput()
 {
     u16 value = JOY_readJoypad(JOY_1);
 
+    if (value & BUTTON_START) {
+        if (!start_was_pressed) {
+            game_paused = !game_paused;
+            start_was_pressed = 1;
+        }
+    } else {
+        start_was_pressed = 0;
+    }
+
     if (control_style == 0){
         // --- Rotation ---
         if (player_rotation_iframe >= player_rotation_iframe_threshold){

--- a/src/title_screen.c
+++ b/src/title_screen.c
@@ -75,6 +75,8 @@ void title_screen(){
         }
 
         if (value & BUTTON_START) {
+            // Prevents reading pause while start is held while entering game loop
+            start_was_pressed = 1;
             break;  // Let's start the game.
         }
 


### PR DESCRIPTION
This pull request introduces a new pause feature to the game, allowing players to pause and resume gameplay using the Start button. It adds the necessary state management, input handling, and a dedicated pause screen that hides all active sprites during the pause. Additionally, there are updates to resource definitions and build configuration.

Pause feature implementation:

* Added `game_paused` and `start_was_pressed` state variables to manage pause logic and prevent rapid toggling when the Start button is held (`inc/globals.h`, `src/main.c`, `src/player.c`, [[1]](diffhunk://#diff-ace751b50871726b1d605bb0bc437210be8be989262037795a08c968886bd5bdR167-R171) [[2]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R33-R35) [[3]](diffhunk://#diff-be6c10a281956279b3126103cd06a5c1573197dd6bb7b13f8b59409d9903f5aaR16-R24).
* Created `pause_screen()` in new files `src/pause.c` and `inc/pause.h`, which displays "PAUSE" and hides all relevant sprites until Start is pressed again (`src/pause.c`, `inc/pause.h`, [[1]](diffhunk://#diff-18a46f2ab80bd62dd2b080257365203072a402f81cc1a4ef6796701c16cbebcbR1-R57) [[2]](diffhunk://#diff-38ce70787f7960de568f394c0a07def67fd9861b64b69cd95a7c0ebefdf851ffR1-R8).
* Integrated pause logic into the main game loop, so pressing Start toggles the pause state and calls the pause screen (`src/main.c`, [src/main.cR108-R110](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R108-R110)).
* Updated input handling to detect Start press events and toggle pause, avoiding repeated toggling while the button is held (`src/player.c`, [src/player.cR16-R24](diffhunk://#diff-be6c10a281956279b3126103cd06a5c1573197dd6bb7b13f8b59409d9903f5aaR16-R24)).
* Ensured that Start does not immediately trigger pause after leaving the title screen by setting `start_was_pressed` when starting the game (`src/title_screen.c`, [src/title_screen.cR78-R79](diffhunk://#diff-969c6b8f7105ccde3a07f4a7556e8c3daf7ba04a3deb7680d5ed42f13711c515R78-R79)).
* Added build system integration for a toolchain via the `Makefile` (`Makefile`, [MakefileR1-R2](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R2)).

<img width="752" height="620" alt="Screenshot 2025-08-15 at 11 01 01 PM" src="https://github.com/user-attachments/assets/933080bd-5f19-4443-9198-a35c52861f5e" />

https://github.com/user-attachments/assets/9d1ba0c3-829b-426b-9e39-7a311c669a53


**Testing**
Testing was performed on both Emulator (Blastem) and real hardware (Model 1 + MegaEverdrive X3)

