### PR TITLE
Clear hud before showing title screen after game over

### DIFF
--- a/inc/hud.h
+++ b/inc/hud.h
@@ -4,5 +4,6 @@
 
 void drawHud(void);
 void initHud(void);
+void clearHud(void);
 
 #endif // HUD_H

--- a/src/game_level_screen.c
+++ b/src/game_level_screen.c
@@ -123,6 +123,8 @@ void level_up(){
         VDP_clearText(8,  1, 8);
         VDP_clearText(23, 1, 8);
 
+        clearHud();
+
         title_screen();   // Show title screen.
 
         PAL_setPalette(PAL3, title_pal_1.data, DMA_QUEUE); // Reset PAL3 after title 

--- a/src/hud.c
+++ b/src/hud.c
@@ -126,6 +126,15 @@ void drawHud(){
 
 }
 
+void clearHud(){
+	// Clear the HUD text
+	VDP_clearText(1, 1, 40); // Clear player score
+	VDP_clearText(31, 1, 40); // Clear enemy score
+	VDP_clearText(15, 2, 9); // Clear level indicator
+	VDP_clearText(17, 1, 5); // Clear game score
+	VDP_clearText(0, 0, 40); // Clear any other text
+}
+
 void initHud(){
 
 	// player_tiles     = VDP_loadTileSet(&player_score_tiles, 1, DMA);


### PR DESCRIPTION
This pull request introduces a new function to clear the HUD and integrates it into the game over reset process to ensure the HUD is cleared when displaying the title screen. The main changes are the addition of the `clearHud` function and its usage during the game over sequence.

HUD management improvements:

* Added a new `clearHud` function to `src/hud.c` that clears various HUD elements using `VDP_clearText`.
* Declared the `clearHud` function in the HUD header file `inc/hud.h`.
* Integrated `clearHud` into the game over process in `src/game_level_screen.c` so the HUD is properly cleared before showing the title screen.

**Before**
<img width="752" height="620" alt="Screenshot 2025-08-15 at 11 16 40 PM" src="https://github.com/user-attachments/assets/3ce7a035-5e2f-482d-9d93-90ac3b0bc7c3" />

**After**
<img width="752" height="620" alt="Screenshot 2025-08-15 at 11 15 42 PM" src="https://github.com/user-attachments/assets/0814f118-b15c-4338-9060-c08abdb0a389" />

**Testing**
Testing was performed on Emulator (Blastem) and real hardware (Model 1 + MegaEverdrive X3)